### PR TITLE
Fix CSC negative uint8 wraparound

### DIFF
--- a/model/csc.py
+++ b/model/csc.py
@@ -13,7 +13,7 @@ class CSC:
         img_h = self.img.shape[0]
         img_w = self.img.shape[1]
         img_c = self.img.shape[2]
-        csc_img = np.empty((img_h, img_w, img_c), np.uint32)
+        csc_img = np.empty((img_h, img_w, img_c), np.int32)
         # for y in range(img_h):
         #     for x in range(img_w):
         #         mulval = self.csc[:,0:3] * self.img[y,x,:]
@@ -27,5 +27,5 @@ class CSC:
         csc_img[:, :, 2] = self.img[:, :, 0] * self.csc[2, 0] + self.img[:, :, 1] * self.csc[2, 1] + self.img[:, :, 2] * self.csc[2, 2] + self.csc[2, 3]
         csc_img = csc_img / 1024
 
-        self.img = csc_img.astype(np.uint8)
+        self.img = np.maximum(csc_img, 0).astype(np.uint8)
         return self.img


### PR DESCRIPTION
Clamp negative CSC results before uint8 conversion to avoid wraparound.